### PR TITLE
[#4] Criar serializers

### DIFF
--- a/back-end/task/serializers.py
+++ b/back-end/task/serializers.py
@@ -1,0 +1,7 @@
+from rest_framework import serializers
+from .models import Task
+
+class TaskSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Task
+        fields = ['id', 'title', 'description', 'completed', 'created_at', 'updated_at']

--- a/back-end/task/serializers.py
+++ b/back-end/task/serializers.py
@@ -2,6 +2,18 @@ from rest_framework import serializers
 from .models import Task
 
 class TaskSerializer(serializers.ModelSerializer):
+    """
+    Serializador para o modelo Task.
+    
+    Este serializador é usado para converter instâncias do modelo Task para e a partir do formato JSON.
+    Ele inclui os seguintes campos:
+    - id: O identificador único da tarefa.
+    - title: O título da tarefa.
+    - description: Uma descrição detalhada da tarefa.
+    - completed: Um booleano indicando se a tarefa foi concluída.
+    - created_at: O timestamp de quando a tarefa foi criada.
+    - updated_at: O timestamp de quando a tarefa foi atualizada pela última vez.
+    """
     class Meta:
         model = Task
         fields = ['id', 'title', 'description', 'completed', 'created_at', 'updated_at']


### PR DESCRIPTION
Adicionado o serializer para o modelo `Task` utilizando o `ModelSerializer` do Django REST Framework. O serializer facilita a conversão entre objetos do modelo e o formato JSON, permitindo:

- Serializar os campos `id`, `title`, `description`, `completed`, `created_at` e `updated_at` para respostas de API.
- Desserializar dados recebidos em formato JSON para criar ou atualizar instâncias do modelo `Task`.