### PR TITLE
Configurar rotas para o modelo Task utilizando DefaultRouter

### DIFF
--- a/back-end/task/urls.py
+++ b/back-end/task/urls.py
@@ -1,4 +1,10 @@
+from django.urls import path, include
+from rest_framework.routers import DefaultRouter
+from .views import TaskViewSet
+
+router = DefaultRouter()
+router.register(r'', TaskViewSet, basename='task')
 
 urlpatterns = [
-
+    path('', include(router.urls)), 
 ]


### PR DESCRIPTION
### Descrição do PR
Este PR configura as rotas para o modelo [`Task`](back-end/task/models.py ) utilizando o `DefaultRouter` do Django REST Framework. As alterações incluem:

- Registro do `TaskViewSet` no `DefaultRouter`, permitindo a criação automática de endpoints para as operações CRUD.
- Inclusão das rotas geradas pelo router no arquivo urls.py ).

Com essa configuração, os endpoints para manipulação de tarefas estão disponíveis e prontos para integração com a API RESTful.